### PR TITLE
Support/pass the backend_eqc tests for leveled

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,8 +35,8 @@
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {tag, "2.1.5"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.3"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "0.1.2"}}},
-        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {tag, "2.1.6"}}},
-        {hyper, ".*", {git, "git://github.com/basho/hyper", {tag, "1.0.0"}}},
+        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "develop-2.2"}}},
+        {hyper, ".*", {git, "git://github.com/basho/hyper", {branch, "basho"}}},
         {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {branch, "master"}}},
         {riak_core, ".*", {git, "https://github.com/martinsumner/riak_core.git", {branch, "mas-nodeworkerpool"}}},
         {eleveldb, ".*", {git, "https://github.com/martinsumner/eleveldb.git", {branch, "mas-leveled-2.0.34"}}}


### PR DESCRIPTION

Up-to-you if you want this, or want to wait until the great merge back to basho/develop-3.0 of all your riak-kv changes.

Changes to enable backend_eqc, and for it to pass (some changes in
leveled, branch rdb/backend_eqc_test)
AND
Make data root configurable by app env

Conflicts:
	rebar.config