### PR TITLE
Switch proxy_object to a separate record

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -670,7 +670,7 @@ parse_object_hook_test() ->
         end,
 
     ?assertMatch(
-       {r_object, _, _, _, _, _, _, false, undefined, undefined},
+       {r_object, _, _, _, _, _, _},
        F([
           {<<"field_bin">>, <<"A">>},
           {<<"field_int">>, <<"1">>}

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -584,15 +584,12 @@ load_built(#state{trees=Trees}) ->
 
 %% Generate a hash value for a `riak_object'
 -spec hash_object({riak_object:bucket(), riak_object:key()},
-                  riak_object_t2b() | riak_object:riak_object(),
-                  version()) -> binary().
-hash_object({Bucket, Key}, RObj0, Version) ->
+                    riak_object_t2b() | 
+                        riak_object:riak_object() | riak_object:proxy_object(),
+                    version()) -> binary().
+hash_object({Bucket, Key}, RObj, Version) ->
     try
-        RObj = case riak_object:is_robject(RObj0) of
-            true -> RObj0;
-            false -> riak_object:from_binary(Bucket, Key, RObj0)
-        end,
-        riak_object:hash(RObj, Version)
+        riak_object:hash(Bucket, Key, RObj, Version)
     catch _:_ ->
             Null = erlang:phash2(<<>>),
             term_to_binary(Null)


### PR DESCRIPTION
Don't want to cause problems with changing r_object in mixed version clusters which try to match on the object.

Dialyzer wasn't happy in a couple of places until I explicitly pattern matched that the inputs ot some functions were r_object (presumably where somewhere deep the input could have been triggered by from_binary and so be p_object)