### PR TITLE
Use exported functions for pool names

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -92,13 +92,12 @@ start(_Type, _StartArgs) ->
                 AF3 = app_helper:get_env(riak_kv, af3_worker_pool_size),
                 AF4 = app_helper:get_env(riak_kv, af4_worker_pool_size),
                 BE = app_helper:get_env(riak_kv, be_worker_pool_size),
-                [{dscp_worker_pool, {riak_kv_worker, AF1, [], [], af1_pool}},
-                    {dscp_worker_pool, {riak_kv_worker, AF2, [], [], af2_pool}},
-                    {dscp_worker_pool, {riak_kv_worker, AF3, [], [], af3_pool}},
-                    {dscp_worker_pool, {riak_kv_worker, AF4, [], [], af4_pool}},
-                    {dscp_worker_pool, {riak_kv_worker, BE, [], [], be_pool}}]
+                [{dscp_worker_pool, {riak_kv_worker, AF1, [], [], riak_core_node_worker_pool:af1()}},
+                 {dscp_worker_pool, {riak_kv_worker, AF2, [], [], riak_core_node_worker_pool:af2()}},
+                 {dscp_worker_pool, {riak_kv_worker, AF3, [], [], riak_core_node_worker_pool:af3()}},
+                 {dscp_worker_pool, {riak_kv_worker, AF4, [], [], riak_core_node_worker_pool:af4()}},
+                 {dscp_worker_pool, {riak_kv_worker, BE, [], [], riak_core_node_worker_pool:be()}}]
         end,
-                
 
     %% Append defaults for riak_kv buckets to the bucket defaults
     %% TODO: Need to revisit this. Buckets are typically created

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -215,20 +215,20 @@
 
 -define(MAX_REBUILD_TIME, 86400).
 
--define(AF1_QUEUE, af1_pool).
+-define(AF1_QUEUE, riak_core_node_worker_pool:af1()).
     %% Assured Forwarding - pool 1
     %% Not currently used
--define(AF2_QUEUE, af2_pool).
+-define(AF2_QUEUE, riak_core_node_worker_pool:af2()).
     %% Assured Forwarding - pool 2
     %% Any other handle_coverage that responds queue (e.g. leveled keylisting)
--define(AF3_QUEUE, af3_pool).
+-define(AF3_QUEUE, riak_core_node_worker_pool:af3()).
     %% Assured Forwarding - pool 3
     %% AAE queries (per-bucket with/without key_range).  AAE queries against
     %% the cached tree do not use a pool (e.g. n_val queries)
--define(AF4_QUEUE, af4_pool).
+-define(AF4_QUEUE, riak_core_node_worker_pool:af4()).
     %% Assured Forwarding - pool 4
     %% perational information queries (e.g. object_stats)
--define(BE_QUEUE, be_pool).
+-define(BE_QUEUE, riak_core_node_worker_pool:be()).
     %% Best efforts (aka scavenger) pool
     %% Rebuilds
 


### PR DESCRIPTION
Rather than atoms. IMO this lowers the sharing and increases the
encapsulation for riak core node worker pool. Hopefully lessens the
chance of simple typos causing hard to find crashes, especially since
xref can be used now.