### PR TITLE
Get FSM review changes

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -233,12 +233,14 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key},
                         UpNodes = riak_core_node_watcher:nodes(riak_kv),
                         riak_core_apl:get_apl_ann(DocIdx, N, UpNodes)
                 end,
+            RequestType = get_default_support_request_type(?DEFAULT_RT),
             new_state_timeout(validate, StateData#state{starttime=riak_core_util:moment(),
                                                 n = N,
                                                 bucket_props=Props,
                                                 preflist2 = Preflist2,
                                                 tracked_bucket = StatTracked,
                                                 crdt_op = CrdtOp,
+                                                request_type=RequestType,
                                                 force_aae = ForceAAE})
     end.
 
@@ -321,15 +323,8 @@ execute(timeout, StateData0=#state{timeout=Timeout,req_id=ReqId,
         _ ->
             ok
     end,
-    RequestType2 =
-        case RequestType of
-            undefined ->
-                get_default_support_request_type(?DEFAULT_RT);
-            _ ->
-                RequestType
-        end,
     StateData =
-        case RequestType2 of
+        case RequestType of
             head ->
                 % Mark the get_core as head_merge so that when determining the
                 % response in riak_get_core the specific head_merge function

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -168,7 +168,6 @@
               node_confirms,%% integer() - number of physically diverse nodes required in preflist on write
               basic_quorum, %% boolean() - whether to use basic_quorum
               notfound_ok,  %% boolean() - whether to treat notfounds as successes
-              force_aae,    %% boolean() - force and aae exchange within the preflist after the GET
               asis,         %% boolean() - whether to send the put without modifying the vclock
               prefix,       %% string() - prefix for resource uris
               riak,         %% local | {node(), atom()} - params for riak client
@@ -423,7 +422,6 @@ malformed_rw_params(RD, Ctx) ->
                 Res,
                 [{#ctx.basic_quorum, "basic_quorum", "default"},
                  {#ctx.notfound_ok, "notfound_ok", "default"},
-                 {#ctx.force_aae, "force_aae", "false"},
                  {#ctx.asis, "asis", "false"}]).
 
 -spec malformed_rw_param({Idx::integer(), Name::string(), Default::string()},
@@ -996,14 +994,11 @@ decode_vclock_header(RD) ->
 ensure_doc(Ctx=#ctx{doc=undefined, key=undefined}) ->
     Ctx#ctx{doc={error, notfound}};
 ensure_doc(Ctx=#ctx{doc=undefined, bucket_type=T, bucket=B, key=K, client=C,
-                    basic_quorum=Quorum, notfound_ok=NotFoundOK, 
-                    force_aae=ForceAAE}) ->
+                    basic_quorum=Quorum, notfound_ok=NotFoundOK}) ->
     case riak_kv_wm_utils:bucket_type_exists(T) of
         true ->
-            Options0 = [deletedvclock, 
-                        {basic_quorum, Quorum},
-                        {notfound_ok, NotFoundOK},
-                        {force_aae, ForceAAE}],
+            Options0 = [deletedvclock, {basic_quorum, Quorum},
+                        {notfound_ok, NotFoundOK}],
             Options = make_options(Options0, Ctx),
             Ctx#ctx{doc=C:get(riak_kv_wm_utils:maybe_bucket_type(T,B), K, Options)};
         false ->

--- a/test/get_fsm_eqc.erl
+++ b/test/get_fsm_eqc.erl
@@ -235,7 +235,8 @@ prop_basic_get() ->
                             [{starttime, riak_core_util:moment()},
                              {n, N},
                              {bucket_props, BucketProps},
-                             {preflist2, PL2}]),
+                             {preflist2, PL2},
+                             {request_type, get}]),
 
         process_flag(trap_exit, true),
         ok = riak_kv_test_util:wait_for_pid(GetPid),


### PR DESCRIPTION
Remove `forceaae` from the HTTP API by reverting that commit (thanks clean history!)

Some changes, mainly making the ordering requirement on get core
results explicit in documentation. 
- I renamed override_nodes, as I found it confusing.
- I renamed head_merge/2 to merge_heads/2 since it had nothing to do with head_merge/1 and made code navigation harder.
- I moved setting request type to prepare to make execute easier to read (and because it makes sense imo)

I hope that none of these are too contentious. 
