### PR TITLE
Develop 2.9.0 prc0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,7 +35,7 @@
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {tag, "2.1.5-225"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.3-225"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "0.1.2"}}},
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {tag, "0.9.9"}}},
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {tag, "0.9.10"}}},
 	{kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.4"}}},
         {riak_core, ".*", {git, "https://github.com/martinsumner/riak_core.git", {branch, "mas-2.2.5-dscpworkerpool"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {tag, "2.1.6-225"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -37,7 +37,7 @@
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "0.1.2"}}},
         {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {tag, "0.9.10"}}},
 	{kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.4"}}},
-        {riak_core, ".*", {git, "https://github.com/martinsumner/riak_core.git", {branch, "mas-2.2.5-dscpworkerpool"}}},
+        {riak_core, ".*", {git, "https://github.com/martinsumner/riak_core.git", {branch, "develop-2.9"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {tag, "2.1.6-225"}}},
         {hyper, ".*", {git, "git://github.com/basho/hyper", {tag, "1.0.1"}}}
        ]}.


### PR DESCRIPTION
Bump versions.  Previously the riak_core branch was pulling in incorrect branches (including for riak_ensemble, which may be related to a make_test failure)