### PR TITLE
Mas i263 alwaysv1

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -429,6 +429,8 @@
 %% on disk.
 %% * 0: Original erlang:term_to_binary format. Higher space overhead.
 %% * 1: New format for more compact storage of small values.
+%% If using the leveled backend object_format 1 will always be used, when
+%% persisting data into the backend - even if 0 has been configured here
 {mapping, "object.format", "riak_kv.object_format", [
   {default, 1},
   {datatype, [{integer, 1}, {integer, 0}]}

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -48,9 +48,10 @@
 -endif.
 
 -define(RIAK_TAG, o_rkv).
--define(CAPABILITIES, [async_fold,
-                        indexes,
+-define(CAPABILITIES, [always_v1obj,
                         head,
+                        indexes,
+                        async_fold,
                         fold_heads,
                         snap_prefold,
                         hot_backup,
@@ -89,7 +90,7 @@ api_version() ->
     {ok, ?API_VERSION}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(state()) -> {ok, [atom()]}.
+-spec capabilities(state()|undefined) -> {ok, [atom()]}.
 capabilities(_) ->
     {ok, ?CAPABILITIES}.
 


### PR DESCRIPTION
Always use object format v1 when doing PUT to a leveled backend